### PR TITLE
Fix url in readme for address docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ usps.Password = ""
 
 ### Address Information APIs
 
-The descriptions are from [here](https://www.usps.com/business/web-tools-apis/address-information.htm).
+The descriptions are from [here](https://www.usps.com/business/web-tools-apis/address-information-api.htm).
 
 The access level for this API doesn't require a password, but only requires a username to be set.
 


### PR DESCRIPTION
https://www.usps.com/business/web-tools-apis/documentation-updates.htm

i assume some of the other links are dead too so ⬆️ that is the main docs link.